### PR TITLE
Getting diffs for specified elements

### DIFF
--- a/dftd3/dftd3.py
+++ b/dftd3/dftd3.py
@@ -275,6 +275,38 @@ def d3(
     return attractive_r6_vdw + attractive_r8_vdw + repulsive_abc
 
 
+def D3_element_wise(elements, config, charges, *coordinates):
+    """Driver for the calculation of chosen derivatives to arbitrary order.
+
+    Parameters
+    ----------
+    elements : tuple
+      following the format Atom,coordinate,Atom,coordinate...
+    config : D3Configuration
+    charges : List[float]
+    coordinates : float
+
+    Returns
+    -------
+    Derivative result for a given adress.
+    """
+    dervs = []
+    derivative_orders = []
+    natoms = len(charges)
+    num_variables = 3 * natoms
+
+    for element in elements:
+        derv_order = [0] * num_variables
+        for directions in range(0, len(element), 2):
+            derv_order[3 * element[directions] + element[directions + 1]] += 1
+        derivative_orders.append(derv_order)
+
+    for d_order in derivative_orders:
+        dervs.append(derv(d3, [config, charges, *coordinates], 2 * [0] + d_order))
+
+    return dervs
+
+
 def D3_derivatives(order, config, charges, *coordinates):
     """Driver for the calculation of derivatives to arbitrary order.
 


### PR DESCRIPTION
in order to differentiate specified elements I made the function `D3_element_wise` which takes a tuple of tuples that contain the "addresses" of a derivative for example, if we want the first derivative with respect to the `z` coordinate of `atom 5` you write `((5,2))`. This also allows us to index the numpy arrays containing the reference numbers. under the hood is doing to same as `D3_derivatives`