### PR TITLE
Use multiprocessing for parallel evaluation of derivatives

### DIFF
--- a/dftd3/cli.py
+++ b/dftd3/cli.py
@@ -43,6 +43,13 @@ def cli():
         help="damping method: zero (default) or Becke-Johnson",
     )
     cli.add_argument(
+        "--nprocs",
+        action="store",
+        default=1,
+        type=int,
+        help="number of processors to use",
+    )
+    cli.add_argument(
         "--s6",
         action="store",
         default="0.0",

--- a/dftd3/jax_diff.py
+++ b/dftd3/jax_diff.py
@@ -12,7 +12,7 @@ def _derv_sequence(orders):
     return sequence
 
 
-def derv(fun, variables, orders) -> float:
+def derv(orders, *, fun, variables) -> float:
     """
     fun: function to differentiate which expects a certain number of variables
     variables: list of variables at which to differentiate the function

--- a/dftd3/utils.py
+++ b/dftd3/utils.py
@@ -183,6 +183,7 @@ def check_inputs(*, charges, coordinates):
 class D3Configuration:
     functional: str
     damp: str = "zero"
+    nprocs: int = 1
     s6: float = field(init=False)
     rs6: float = field(init=False)
     s8: float = field(init=False)


### PR DESCRIPTION
The evaluation of derivatives is embarrassing parallel. This PR uses the `multiprocessing` module to split the work among a user-defined number of processes.